### PR TITLE
Don't specify redis protocol in Redis::connect method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,7 +221,7 @@ No extra extensions are needed
 $redis = new Redis();
 
 // Wait for redis to be ready
-$redis = RxNet\awaitOnce($redis->connect('redis://localhost:6379'));
+$redis = RxNet\awaitOnce($redis->connect('127.0.0.1:6379'));
 
 $redis->get('key')
   ->subscribe(new StdoutObserver());


### PR DESCRIPTION
If the redis protocol is specified in the `connect` an exception is thrown saying given URL can not be parsed
