### PR TITLE
Fix invalid route matching in Router

### DIFF
--- a/specs/Routing/router.spec.php
+++ b/specs/Routing/router.spec.php
@@ -1,0 +1,46 @@
+<?php
+
+describe("Router", function () {
+
+    context("route()", function () {
+
+        it("Exact match simple routes", function () {
+            $router = new \Rxnet\Routing\Router();
+            $matches = [];
+
+            $router->route("/download")
+                ->subscribeCallback(function () use (&$matches) {
+                    $matches[] = '/download';
+                });
+
+            $router->route("/report/download")
+                ->subscribeCallback(function () use (&$matches) {
+                    $matches[] = '/report/download';
+                });
+
+            $router->route("/report/downloaded")
+                ->subscribeCallback(function () use (&$matches) {
+                    $matches[] = '/report/downloaded';
+                });
+
+
+            $router->onNext(new \Rxnet\Event\Event("/report/downloaded"));
+            expect($matches)->to->equal(['/report/downloaded']);
+
+            $matches = [];
+            $router->onNext(new \Rxnet\Event\Event("/report/download"));
+            expect($matches)->to->equal(['/report/download']);
+
+            $matches = [];
+            $router->onNext(new \Rxnet\Event\Event("/download"));
+            expect($matches)->to->equal(['/download']);
+
+            expect(function() use ($router) {
+                $router->onNext(new \Rxnet\Event\Event("/downloaded"));
+            })->to->throw(\Rxnet\Exceptions\RouteNotFoundException::class);
+
+        });
+
+    });
+
+});

--- a/src/Rxnet/Routing/Router.php
+++ b/src/Rxnet/Routing/Router.php
@@ -42,7 +42,7 @@ class Router implements ObserverInterface
 
         foreach ($detail as $routeData) {
             $b = $this->buildRegexForRoute($routeData);
-            $regex = '(' . $b[0] . ')';
+            $regex = '~^(' . $b[0] . ')$~';
             $routeMap = $b[1];
             $routes[] = compact('regex', 'routeMap', 'where');
         }


### PR DESCRIPTION

Consider the following routes declarations : 

- /download
- /report/download
- /report/downloaded

If an event with name "/report/downloaded" is dispatched, it should match the "/report/downloaded" route.
The current Router triggers the /download route instead :-(

This should PR fix this issue.
