### PR TITLE
fix case mismatch in DnsRequest class

### DIFF
--- a/src/Rxnet/Dns/DnsRequest.php
+++ b/src/Rxnet/Dns/DnsRequest.php
@@ -1,5 +1,5 @@
 <?php
-namespace RxNet\Dns;
+namespace Rxnet\Dns;
 
 
 use Rx\Subject\Subject;


### PR DESCRIPTION
In my case I have an error because there is a typo in the DnsRequest class namespace