### PR TITLE
add guzzlehttp/psr7 1.4 to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "ramsey/uuid": "^3.5.1",
     "nikic/fast-route": "^1.2",
     "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/psr7": "~1.4.0",
     "domraider/libdns": "^1.1",
     "domraider/bunny": "@dev",
     "clue/redis-react": "^1.0",


### PR DESCRIPTION
Curent Http header parsing is not compatible with new Guzzle `\GuzzleHttp\Psr7\parse_request($headers);`